### PR TITLE
chore: SecurityConfig 및 TokenAuthenticationFilter내에 화이트리스트 추가

### DIFF
--- a/src/main/java/com/almang/inventory/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/almang/inventory/global/config/security/SecurityConfig.java
@@ -32,6 +32,33 @@ public class SecurityConfig {
     private final UserRepository userRepository;
     private final JwtAuthEntryPoint jwtAuthEntryPoint;
 
+    private static final String[] PUBLIC_APIS = {
+            // Auth
+            "/api/v1/auth/login",
+            "/api/v1/auth/reset-password",
+            "/api/v1/auth/reissue",
+
+            // Store admin
+            "/api/v1/store/admin",
+            "/api/v1/admin/store",
+
+            // Swagger / API docs
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/v3/api-docs",
+            "/swagger-resources/**",
+
+            // H2 console
+            "/h2-console/**",
+
+            // 기타 공개 엔드포인트
+            "/docs/**",
+            "/health",
+            "/error",
+            "/favicon.ico"
+    };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
@@ -40,8 +67,11 @@ public class SecurityConfig {
                 .headers(h -> h.frameOptions(FrameOptionsConfig::sameOrigin)) // H2 콘솔 접근 시 iframe 사용 허용 (동일 출처만 허용하여 보안 유지)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/logout").authenticated()
-                        .anyRequest().permitAll() // 추후 변경 예정
+                        // 공개 엔드포인트
+                        .requestMatchers(PUBLIC_APIS).permitAll()
+
+                        // 다른 엔드포인트는 인증 필요
+                        .anyRequest().authenticated()
                 )
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(jwtAuthEntryPoint))

--- a/src/main/java/com/almang/inventory/global/security/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/almang/inventory/global/security/jwt/TokenAuthenticationFilter.java
@@ -31,16 +31,29 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private final UserRepository userRepository;
     private static final String TOKEN_PREFIX = "Bearer ";
 
-    // 화이트리스트
     private final List<String> whitelist = List.of(
+            // Auth
             "/api/v1/auth/login",
+            "/api/v1/auth/reset-password",
             "/api/v1/auth/reissue",
+
+            // Store admin
             "/api/v1/store/admin",
+            "/api/v1/admin/store",
+
+            // Swagger / API docs
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/swagger-resources",
+
+            // H2 console
+            "/h2-console",
+
+            // 기타 공개 엔드포인트
             "/docs",
             "/health",
-            "/h2-console",
-            "/swagger-ui",
-            "/v3/api-docs"
+            "/error",
+            "/favicon.ico"
     );
 
     @Override


### PR DESCRIPTION
## ✨ 작업 내용
- SecurityConfig 및 TokenAuthenticationFilter내에 화이트리스트 추가

---

## 📝 적용 범위
- `/global/config`
- `/global/security`

---

## 📌 참고 사항
- 관련 이슈(Closed #95)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 공개 엔드포인트 관리 체계화
  * API 문서, 상태 확인, 암호 재설정 등 추가 엔드포인트 인증 불필요하게 변경
  * 관리자 관련 특정 엔드포인트에 대한 공개 접근 확대

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->