### PR TITLE
refactor: 재고 변경 구간 비관적 락 적용 및 동시성 검증

### DIFF
--- a/src/main/java/com/almang/inventory/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/almang/inventory/inventory/repository/InventoryRepository.java
@@ -2,11 +2,13 @@ package com.almang.inventory.inventory.repository;
 
 import com.almang.inventory.inventory.domain.Inventory;
 import com.almang.inventory.product.domain.Product;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -42,4 +44,30 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
         WHERE product.id in :productIds
     """)
     List<Inventory> findAllWithProductByProductIds(@Param("productIds") List<Long> productIds);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT inventory 
+        FROM Inventory inventory 
+        WHERE inventory.product.id = :productId
+    """)
+    Optional<Inventory> findWithLockByProductId(@Param("productId") Long productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT inventory 
+        FROM Inventory inventory 
+        WHERE inventory.id = :inventoryId
+    """)
+    Optional<Inventory> findWithLockById(@Param("inventoryId") Long inventoryId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT inventory 
+        FROM Inventory inventory 
+        JOIN FETCH inventory.product product 
+        WHERE product.id IN :productIds 
+        ORDER BY product.id ASC
+    """)
+    List<Inventory> findAllWithLockByProductIdIn(@Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/almang/inventory/inventory/service/InventoryService.java
+++ b/src/main/java/com/almang/inventory/inventory/service/InventoryService.java
@@ -45,7 +45,7 @@ public class InventoryService {
     @Transactional
     public void increaseIncomingStockFromOrder(Product product, BigDecimal quantity) {
         log.info("[InventoryService] 발주 생성으로 입고 예정 수량 증가 요청 - productId: {}", product.getId());
-        Inventory inventory = findInventoryByProductId(product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
         inventory.increaseIncoming(quantity);
         log.info("[InventoryService] 발주 생성으로 입고 예정 수량 증가 성공 - inventoryId: {}", inventory.getId());
     }
@@ -53,7 +53,7 @@ public class InventoryService {
     @Transactional
     public void decreaseIncomingStockFromOrder(Product product, BigDecimal quantity) {
         log.info("[InventoryService] 발주 항목 삭제로 입고 예정 수량 감소 요청 - productId: {}", product.getId());
-        Inventory inventory = findInventoryByProductId(product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
         inventory.decreaseIncoming(quantity);
         log.info("[InventoryService] 발주 항목 삭제로 입고 예정 수량 감소 성공 - inventoryId: {}", inventory.getId());
     }
@@ -65,7 +65,7 @@ public class InventoryService {
         }
 
         log.info("[InventoryService] 발주 수정으로 입고 예정 수량 변경 요청 - productId: {}", product.getId());
-        Inventory inventory = findInventoryByProductId(product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
 
         if (diff.compareTo(BigDecimal.ZERO) > 0) {
             inventory.increaseIncoming(diff);
@@ -79,7 +79,7 @@ public class InventoryService {
     @Transactional
     public void applyReceipt(Product product, BigDecimal expected, BigDecimal actual) {
         log.info("[InventoryService] 입고 이후 입고 예정 수량 감소 및 재고 수량 증가 요청 - productId: {}", product.getId());
-        Inventory inventory = findInventoryByProductId(product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
         inventory.confirmIncoming(expected, actual);
         log.info("[InventoryService] 입고 이후 입고 예정 수량 감소 및 재고 수량 증가 성공 - inventoryId: {}", inventory.getId());
     }
@@ -87,9 +87,54 @@ public class InventoryService {
     @Transactional
     public void cancelIncomingReservation(Product product, BigDecimal quantity) {
         log.info("[InventoryService] 입고 취소로 입고 예정 수량 감소 요청 - productId: {}", product.getId());
-        Inventory inventory = findInventoryByProductId(product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
         inventory.decreaseIncoming(quantity);
         log.info("[InventoryService] 입고 취소로 입고 예정 수량 감소 성공 - inventoryId: {}", inventory.getId());
+    }
+
+    @Transactional
+    public BigDecimal getAvailableStockWithLock(Product product) {
+        log.info("[InventoryService] 출고용 가용 재고 조회 요청 - productId: {}", product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
+        return inventory.getAvailableStock();
+    }
+
+    @Transactional
+    public void increaseOutgoingReservation(Product product, BigDecimal quantity) {
+        log.info("[InventoryService] 출고 생성으로 출고 예정 수량 증가 요청 - productId: {}", product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
+        inventory.increaseOutgoing(quantity);
+        log.info("[InventoryService] 출고 생성으로 출고 예정 수량 증가 성공 - inventoryId: {}", inventory.getId());
+    }
+
+    @Transactional
+    public void decreaseOutgoingReservation(Product product, BigDecimal quantity) {
+        log.info("[InventoryService] 출고 취소로 출고 예정 수량 감소 요청 - productId: {}", product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
+        inventory.decreaseOutgoing(quantity);
+        log.info("[InventoryService] 출고 취소로 출고 예정 수량 감소 성공 - inventoryId: {}", inventory.getId());
+    }
+
+    @Transactional
+    public void updateOutgoingReservation(Product product, BigDecimal diff) {
+        log.info("[InventoryService] 출고 수정으로 출고 예정 수량 변경 요청 - productId: {}", product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
+
+        if (diff.compareTo(BigDecimal.ZERO) > 0) {
+            inventory.increaseOutgoing(diff);
+        } else if (diff.compareTo(BigDecimal.ZERO) < 0) {
+            inventory.decreaseOutgoing(diff.abs());
+        }
+
+        log.info("[InventoryService] 출고 수정으로 출고 예정 수량 변경 성공 - inventoryId: {}", inventory.getId());
+    }
+
+    @Transactional
+    public void confirmOutgoing(Product product, BigDecimal quantity) {
+        log.info("[InventoryService] 출고 확정으로 출고 예정 및 창고 재고 차감 요청 - productId: {}", product.getId());
+        Inventory inventory = findInventoryByProductIdWithLock(product.getId());
+        inventory.confirmOutgoing(quantity);
+        log.info("[InventoryService] 출고 확정으로 출고 예정 및 창고 재고 차감 성공 - inventoryId: {}", inventory.getId());
     }
 
     @Transactional
@@ -98,7 +143,7 @@ public class InventoryService {
         Store store = context.store();
 
         log.info("[InventoryService] 재고 수동 수정 요청 - userId: {}, storeId: {}", userId, store.getId());
-        Inventory inventory = findInventoryByIdAndValidateAccess(inventoryId, store);
+        Inventory inventory = findInventoryByIdWithLockAndValidateAccess(inventoryId, store);
         validateProductMatch(inventory, request.productId());
 
         inventory.updateManually(
@@ -169,12 +214,12 @@ public class InventoryService {
     }
 
     @Transactional
-        public InventoryResponse moveInventory(Long inventoryId, MoveInventoryRequest request, Long userId) {
+    public InventoryResponse moveInventory(Long inventoryId, MoveInventoryRequest request, Long userId) {
         UserStoreContext context = userContextProvider.findUserAndStore(userId);
         Store store = context.store();
 
         log.info("[InventoryService] 재고 이동 요청 - userId: {}, storeId: {}", userId, store.getId());
-        Inventory inventory = findInventoryByIdAndValidateAccess(inventoryId, store);
+        Inventory inventory = findInventoryByIdWithLockAndValidateAccess(inventoryId, store);
 
         if (request.direction() == InventoryMoveDirection.WAREHOUSE_TO_DISPLAY) {
             inventory.moveWarehouseToDisplay(request.quantity());
@@ -204,8 +249,23 @@ public class InventoryService {
                 .orElseThrow(() -> new BaseException(ErrorCode.INVENTORY_NOT_FOUND));
     }
 
+    private Inventory findInventoryByProductIdWithLock(Long productId) {
+        return inventoryRepository.findWithLockByProductId(productId)
+                .orElseThrow(() -> new BaseException(ErrorCode.INVENTORY_NOT_FOUND));
+    }
+
     private Inventory findInventoryByIdAndValidateAccess(Long inventoryId, Store store) {
         Inventory inventory =  inventoryRepository.findById(inventoryId)
+                .orElseThrow(() -> new BaseException(ErrorCode.INVENTORY_NOT_FOUND));
+
+        if (!inventory.getProduct().getStore().getId().equals(store.getId())) {
+            throw new BaseException(ErrorCode.INVENTORY_ACCESS_DENIED);
+        }
+        return inventory;
+    }
+
+    private Inventory findInventoryByIdWithLockAndValidateAccess(Long inventoryId, Store store) {
+        Inventory inventory =  inventoryRepository.findWithLockById(inventoryId)
                 .orElseThrow(() -> new BaseException(ErrorCode.INVENTORY_NOT_FOUND));
 
         if (!inventory.getProduct().getStore().getId().equals(store.getId())) {

--- a/src/main/java/com/almang/inventory/wholesale/service/WholesaleService.java
+++ b/src/main/java/com/almang/inventory/wholesale/service/WholesaleService.java
@@ -6,8 +6,8 @@ import com.almang.inventory.global.context.UserContextProvider.UserStoreContext;
 import com.almang.inventory.global.exception.BaseException;
 import com.almang.inventory.global.exception.ErrorCode;
 import com.almang.inventory.global.util.PaginationUtil;
-import com.almang.inventory.inventory.domain.Inventory;
 import com.almang.inventory.inventory.repository.InventoryRepository;
+import com.almang.inventory.inventory.service.InventoryService;
 import com.almang.inventory.product.domain.Product;
 import com.almang.inventory.product.repository.ProductRepository;
 import com.almang.inventory.store.domain.Store;
@@ -44,6 +44,7 @@ public class WholesaleService {
     private final WholesaleRepository wholesaleRepository;
     private final ProductRepository productRepository;
     private final InventoryRepository inventoryRepository;
+    private final InventoryService inventoryService;
     private final UserContextProvider userContextProvider;
 
     @Transactional
@@ -109,11 +110,9 @@ public class WholesaleService {
 
         // 출고 완료 후 재고 차감
         for (WholesaleItem item : wholesale.getItems()) {
-            Inventory inventory = findInventoryByProductId(item.getProduct().getId());
-            
             // 재고 부족 항목인 경우, 현재 oversubscription(가용 재고 < 0)이 해소됐는지 확인
             if (item.getInsufficientStock()) {
-                BigDecimal availableStock = inventory.getAvailableStock();
+                BigDecimal availableStock = inventoryService.getAvailableStockWithLock(item.getProduct());
                 if (availableStock.compareTo(BigDecimal.ZERO) < 0) {
                     // 여전히 전체 출고 예약 합보다 창고 재고가 적으면 확정을 막음
                     throw new BaseException(ErrorCode.NOT_ENOUGH_STOCK,
@@ -123,8 +122,8 @@ public class WholesaleService {
                 // oversubscription이 해소되었으면 부족 플래그 해제
                 item.setInsufficientStock(false);
             }
-            
-            inventory.confirmOutgoing(item.getQuantity());
+
+            inventoryService.confirmOutgoing(item.getProduct(), item.getQuantity());
         }
 
         log.info("[WholesaleService] 출고 완료 처리 성공 - wholesaleId: {}", wholesale.getId());
@@ -148,8 +147,7 @@ public class WholesaleService {
 
         // 출고 취소 후 출고 예정 수량 차감
         for (WholesaleItem item : wholesale.getItems()) {
-            Inventory inventory = findInventoryByProductId(item.getProduct().getId());
-            inventory.decreaseOutgoing(item.getQuantity());
+            inventoryService.decreaseOutgoingReservation(item.getProduct(), item.getQuantity());
         }
 
         log.info("[WholesaleService] 출고 취소 성공 - wholesaleId: {}", wholesale.getId());
@@ -204,34 +202,32 @@ public class WholesaleService {
                                 String.format("출고 항목 ID %d를 찾을 수 없습니다.", itemRequest.wholesaleItemId())));
 
                 Product product = item.getProduct();
-                Inventory inventory = findInventoryByProductId(product.getId());
 
                 // 수량 차이 계산
                 BigDecimal diff = itemRequest.quantity().subtract(item.getQuantity());
 
                 if (diff.compareTo(BigDecimal.ZERO) > 0) {
                     // 수량 증가: 가용 재고 검증 후 출고 예정 증가
-                    BigDecimal availableStock = inventory.getAvailableStock();
+                    BigDecimal availableStock = inventoryService.getAvailableStockWithLock(product);
                     boolean isInsufficient = availableStock.compareTo(diff) < 0;
-                    
+
                     if (isInsufficient) {
                         throw new BaseException(ErrorCode.NOT_ENOUGH_STOCK,
                                 String.format("상품 '%s'의 창고 재고가 부족합니다. (요청 증가: %s, 가용 재고: %s)",
                                         product.getName(), diff, availableStock));
                     }
-                    inventory.increaseOutgoing(diff);
+                    inventoryService.updateOutgoingReservation(product, diff);
                     // 수량 증가 후 재고가 충분하면 부족 플래그 해제
                     item.setInsufficientStock(false);
                 } else if (diff.compareTo(BigDecimal.ZERO) < 0) {
-                    // 수량 감소: 출고 예정 감소
-                    inventory.decreaseOutgoing(diff.abs());
+                    inventoryService.updateOutgoingReservation(product, diff);
                     // 수량이 감소했으므로 재고 상태 재확인
-                    BigDecimal availableStock = inventory.getAvailableStock();
+                    BigDecimal availableStock = inventoryService.getAvailableStockWithLock(product);
                     boolean isInsufficient = availableStock.compareTo(itemRequest.quantity()) < 0;
                     item.setInsufficientStock(isInsufficient);
                 } else {
                     // 수량 변경 없음: 재고 상태 재확인
-                    BigDecimal availableStock = inventory.getAvailableStock();
+                    BigDecimal availableStock = inventoryService.getAvailableStockWithLock(product);
                     boolean isInsufficient = availableStock.compareTo(itemRequest.quantity()) < 0;
                     item.setInsufficientStock(isInsufficient);
                 }
@@ -262,17 +258,14 @@ public class WholesaleService {
 
         for (CreateWholesaleItemRequest request : requests) {
             Product product = findProductByIdAndValidateAccess(request.productId(), store);
-            Inventory inventory = findInventoryByProductId(product.getId());
 
             // 재고 검증 (가용 재고 = 창고 재고 - 출고 예정 수량)
-            BigDecimal availableStock = inventory.getAvailableStock();
+            BigDecimal availableStock = inventoryService.getAvailableStockWithLock(product);
             boolean isInsufficient = availableStock.compareTo(request.quantity()) < 0;
-            
-            // 재고 부족 여부와 관계없이 출고 예정 수량 증가 (데이터 일관성 유지)
-            inventory.increaseOutgoing(request.quantity());
-            
+            inventoryService.increaseOutgoingReservation(product, request.quantity());
+
             if (isInsufficient) {
-                log.warn("[WholesaleService] 재고 부족 - 상품: {}, 요청 수량: {}, 가용 재고: {}", 
+                log.warn("[WholesaleService] 재고 부족 - 상품: {}, 요청 수량: {}, 가용 재고: {}",
                         product.getName(), request.quantity(), availableStock);
             }
 
@@ -316,11 +309,6 @@ public class WholesaleService {
             throw new BaseException(ErrorCode.PRODUCT_ACCESS_DENIED);
         }
         return product;
-    }
-
-    private Inventory findInventoryByProductId(Long productId) {
-        return inventoryRepository.findByProduct_Id(productId)
-                .orElseThrow(() -> new BaseException(ErrorCode.INVENTORY_NOT_FOUND));
     }
 
     private void validateWholesaleItemsNotEmpty(List<CreateWholesaleItemRequest> items) {
@@ -372,4 +360,3 @@ public class WholesaleService {
                 storeId, status, orderReference, start, end, pageable);
     }
 }
-

--- a/src/test/java/com/almang/inventory/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/almang/inventory/inventory/service/InventoryServiceTest.java
@@ -250,21 +250,21 @@ class InventoryServiceTest {
                 updated.getDisplayStock().stripTrailingZeros().toPlainString(),
                 updated.getWarehouseStock().stripTrailingZeros().toPlainString()
         );
-        System.out.println("=== BEFORE LOCK SUMMARY ===");
+        System.out.println("=== 락 적용 전 요약 ===");
         System.out.printf(
-                "INITIAL: display=%s, warehouse=%s%n",
+                "초기값: display=%s, warehouse=%s%n",
                 BigDecimal.valueOf(10).stripTrailingZeros().toPlainString(),
                 BigDecimal.valueOf(20).stripTrailingZeros().toPlainString()
         );
-        System.out.println("T1 TARGET: display=100, warehouse=20");
-        System.out.println("T2 TARGET: display=10, warehouse=200");
+        System.out.println("T1 목표값: display=100, warehouse=20");
+        System.out.println("T2 목표값: display=10, warehouse=200");
         System.out.printf(
-                "FINAL: display=%s, warehouse=%s%n",
+                "최종값: display=%s, warehouse=%s%n",
                 updated.getDisplayStock().stripTrailingZeros().toPlainString(),
                 updated.getWarehouseStock().stripTrailingZeros().toPlainString()
         );
-        System.out.println("RESULT: lost update reproduced");
-        System.out.println("===========================");
+        System.out.println("결과: lost update 재현");
+        System.out.println("======================");
 
         assertThat(results)
                 .extracting(result -> result[0].stripTrailingZeros().toPlainString() + "," + result[1].stripTrailingZeros().toPlainString())
@@ -327,7 +327,7 @@ class InventoryServiceTest {
             await(start);
             InventoryResponse response = inventoryService.updateInventory(inventory.getId(), displayUpdateRequest, user.getId());
             System.out.printf(
-                    "[LOCK-T1] response display=%s, warehouse=%s%n",
+                    "[LOCK-T1] 응답값 display=%s, warehouse=%s%n",
                     response.displayStock().stripTrailingZeros().toPlainString(),
                     response.warehouseStock().stripTrailingZeros().toPlainString()
             );
@@ -339,7 +339,7 @@ class InventoryServiceTest {
             await(start);
             InventoryResponse response = inventoryService.updateInventory(inventory.getId(), warehouseUpdateRequest, user.getId());
             System.out.printf(
-                    "[LOCK-T2] response display=%s, warehouse=%s%n",
+                    "[LOCK-T2] 응답값 display=%s, warehouse=%s%n",
                     response.displayStock().stripTrailingZeros().toPlainString(),
                     response.warehouseStock().stripTrailingZeros().toPlainString()
             );
@@ -365,26 +365,105 @@ class InventoryServiceTest {
                 updated.getDisplayStock().stripTrailingZeros().toPlainString(),
                 updated.getWarehouseStock().stripTrailingZeros().toPlainString()
         );
-        System.out.println("=== AFTER LOCK SUMMARY ===");
+        System.out.println("=== 락 적용 후 요약 ===");
         System.out.printf(
-                "INITIAL: display=%s, warehouse=%s%n",
+                "초기값: display=%s, warehouse=%s%n",
                 BigDecimal.valueOf(10).stripTrailingZeros().toPlainString(),
                 BigDecimal.valueOf(20).stripTrailingZeros().toPlainString()
         );
-        System.out.println("T1 TARGET: display=100, warehouse=20");
-        System.out.println("T2 TARGET: display=10, warehouse=200");
+        System.out.println("T1 목표값: display=100, warehouse=20");
+        System.out.println("T2 목표값: display=10, warehouse=200");
         System.out.printf(
-                "FINAL: display=%s, warehouse=%s%n",
+                "최종값: display=%s, warehouse=%s%n",
                 updated.getDisplayStock().stripTrailingZeros().toPlainString(),
                 updated.getWarehouseStock().stripTrailingZeros().toPlainString()
         );
-        System.out.println("RESULT: both changes preserved");
-        System.out.println("==========================");
+        System.out.println("결과: 두 변경 모두 보존");
+        System.out.println("=====================");
 
         assertThat(firstResponse).isNotNull();
         assertThat(secondResponse).isNotNull();
         assertThat(updated.getDisplayStock()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(updated.getWarehouseStock()).isEqualByComparingTo(BigDecimal.valueOf(200));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void 비관적_락을_적용하면_동일_재고에_대한_동시_이동_요청은_하나만_성공한다() throws Exception {
+        // given
+        Store store = newStore("락이동상점");
+        User user = newUser(store, "moveLockUser");
+        Vendor vendor = newVendor(store, "발주처");
+        Product product = newProduct(store, vendor, "상품1", "MOVE-LOCK-001");
+
+        InitialInventoryValues initialInventoryValues = new InitialInventoryValues(
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.valueOf(10),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO
+        );
+        inventoryService.createInventory(product, initialInventoryValues);
+        Inventory inventory = inventoryRepository.findByProduct_Id(product.getId())
+                .orElseThrow();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        Callable<String> moveTask = () -> {
+            ready.countDown();
+            await(start);
+            try {
+                InventoryResponse response = inventoryService.moveInventory(
+                        inventory.getId(),
+                        new MoveInventoryRequest(BigDecimal.valueOf(7), InventoryMoveDirection.WAREHOUSE_TO_DISPLAY),
+                        user.getId()
+                );
+                String successLog = String.format(
+                        "성공 display=%s, warehouse=%s",
+                        response.displayStock().stripTrailingZeros().toPlainString(),
+                        response.warehouseStock().stripTrailingZeros().toPlainString()
+                );
+                System.out.printf("[MOVE] %s%n", successLog);
+                return successLog;
+            } catch (BaseException e) {
+                String failLog = "실패 error=" + e.getErrorCode().name();
+                System.out.printf("[MOVE] %s%n", failLog);
+                return failLog;
+            }
+        };
+
+        // when
+        Future<String> future1 = executorService.submit(moveTask);
+        Future<String> future2 = executorService.submit(moveTask);
+
+        ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+
+        String result1 = future1.get(10, TimeUnit.SECONDS);
+        String result2 = future2.get(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // then
+        Inventory updated = inventoryRepository.findById(inventory.getId())
+                .orElseThrow();
+        System.out.println("=== 동시 이동 락 검증 요약 ===");
+        System.out.println("초기값: display=0, warehouse=10");
+        System.out.printf("결과1: %s%n", result1);
+        System.out.printf("결과2: %s%n", result2);
+        System.out.printf(
+                "최종값: display=%s, warehouse=%s%n",
+                updated.getDisplayStock().stripTrailingZeros().toPlainString(),
+                updated.getWarehouseStock().stripTrailingZeros().toPlainString()
+        );
+        System.out.println("기대결과: 하나 성공, 하나 실패(WAREHOUSE_STOCK_NOT_ENOUGH)");
+        System.out.println("==================================");
+
+        assertThat(List.of(result1, result2).stream().filter(result -> result.startsWith("성공")).count()).isEqualTo(1);
+        assertThat(List.of(result1, result2).stream().filter(result -> result.contains(ErrorCode.WAREHOUSE_STOCK_NOT_ENOUGH.name())).count()).isEqualTo(1);
+        assertThat(updated.getDisplayStock()).isEqualByComparingTo(BigDecimal.valueOf(7));
+        assertThat(updated.getWarehouseStock()).isEqualByComparingTo(BigDecimal.valueOf(3));
     }
 
     private static void await(CountDownLatch latch) {

--- a/src/test/java/com/almang/inventory/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/almang/inventory/inventory/service/InventoryServiceTest.java
@@ -26,11 +26,22 @@ import com.almang.inventory.vendor.domain.Vendor;
 import com.almang.inventory.vendor.domain.VendorChannel;
 import com.almang.inventory.vendor.repository.VendorRepository;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
 @Transactional
@@ -43,6 +54,7 @@ class InventoryServiceTest {
     @Autowired private UserRepository userRepository;
     @Autowired private VendorRepository vendorRepository;
     @Autowired private ProductRepository productRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
 
     private Store newStore(String name) {
         return storeRepository.save(
@@ -151,6 +163,116 @@ class InventoryServiceTest {
         assertThat(updated.getOutgoingReserved()).isEqualByComparingTo(newOutgoing);
         assertThat(updated.getIncomingReserved()).isEqualByComparingTo(newIncoming);
         assertThat(updated.getReorderTriggerPoint()).isEqualByComparingTo(newReorderTrigger);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void 동일한_재고를_동시에_수정하면_마지막_커밋이_앞선_변경을_덮어쓸_수_있다() throws Exception {
+        // given
+        Store store = newStore("동시성이동상점");
+        User user = newUser(store, "concurrencyUser");
+        Vendor vendor = newVendor(store, "발주처");
+        Product product = newProduct(store, vendor, "상품1", "P001");
+
+        InitialInventoryValues initialInventoryValues = new InitialInventoryValues(
+                BigDecimal.ZERO,
+                BigDecimal.valueOf(10),
+                BigDecimal.valueOf(20),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO
+        );
+        inventoryService.createInventory(product, initialInventoryValues);
+        Inventory inventory = inventoryRepository.findByProduct_Id(product.getId())
+                .orElseThrow();
+
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        int requestCount = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch ready = new CountDownLatch(requestCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Callable<BigDecimal[]>> tasks = List.of(
+                () -> transactionTemplate.execute(status -> {
+                    Inventory loaded = inventoryRepository.findById(inventory.getId()).orElseThrow();
+                    System.out.printf(
+                            "[T1] loaded display=%s, warehouse=%s%n",
+                            loaded.getDisplayStock().stripTrailingZeros().toPlainString(),
+                            loaded.getWarehouseStock().stripTrailingZeros().toPlainString()
+                    );
+                    ready.countDown();
+                    await(start);
+                    loaded.updateManually(BigDecimal.valueOf(100), null, null, null, null);
+                    System.out.printf(
+                            "[T1] updated display=%s, warehouse=%s%n",
+                            loaded.getDisplayStock().stripTrailingZeros().toPlainString(),
+                            loaded.getWarehouseStock().stripTrailingZeros().toPlainString()
+                    );
+                    return new BigDecimal[]{loaded.getDisplayStock(), loaded.getWarehouseStock()};
+                }),
+                () -> transactionTemplate.execute(status -> {
+                    Inventory loaded = inventoryRepository.findById(inventory.getId()).orElseThrow();
+                    System.out.printf(
+                            "[T2] loaded display=%s, warehouse=%s%n",
+                            loaded.getDisplayStock().stripTrailingZeros().toPlainString(),
+                            loaded.getWarehouseStock().stripTrailingZeros().toPlainString()
+                    );
+                    ready.countDown();
+                    await(start);
+                    loaded.updateManually(null, BigDecimal.valueOf(200), null, null, null);
+                    System.out.printf(
+                            "[T2] updated display=%s, warehouse=%s%n",
+                            loaded.getDisplayStock().stripTrailingZeros().toPlainString(),
+                            loaded.getWarehouseStock().stripTrailingZeros().toPlainString()
+                    );
+                    return new BigDecimal[]{loaded.getDisplayStock(), loaded.getWarehouseStock()};
+                })
+        );
+
+        // when
+        List<Future<BigDecimal[]>> futures = new ArrayList<>();
+        for (Callable<BigDecimal[]> task : tasks) {
+            futures.add(executorService.submit(task));
+        }
+
+        ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+
+        List<BigDecimal[]> results = new ArrayList<>();
+        for (Future<BigDecimal[]> future : futures) {
+            results.add(future.get(10, TimeUnit.SECONDS));
+        }
+        executorService.shutdown();
+
+        // then
+        Inventory updated = inventoryRepository.findById(inventory.getId())
+                .orElseThrow();
+        System.out.printf(
+                "[FINAL] display=%s, warehouse=%s%n",
+                updated.getDisplayStock().stripTrailingZeros().toPlainString(),
+                updated.getWarehouseStock().stripTrailingZeros().toPlainString()
+        );
+
+        assertThat(results)
+                .extracting(result -> result[0].stripTrailingZeros().toPlainString() + "," + result[1].stripTrailingZeros().toPlainString())
+                .containsExactlyInAnyOrder("100,20", "10,200");
+        assertThat(
+                updated.getDisplayStock().compareTo(BigDecimal.valueOf(10)) == 0
+                        || updated.getDisplayStock().compareTo(BigDecimal.valueOf(100)) == 0
+        ).isTrue();
+        assertThat(
+                updated.getWarehouseStock().compareTo(BigDecimal.valueOf(20)) == 0
+                        || updated.getWarehouseStock().compareTo(BigDecimal.valueOf(200)) == 0
+        ).isTrue();
+        assertThat(updated.getDisplayStock().equals(BigDecimal.valueOf(100))
+                && updated.getWarehouseStock().equals(BigDecimal.valueOf(200))).isFalse();
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("동시성 테스트 대기 중 인터럽트가 발생했습니다.", e);
+        }
     }
 
     @Test

--- a/src/test/java/com/almang/inventory/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/almang/inventory/inventory/service/InventoryServiceTest.java
@@ -250,6 +250,21 @@ class InventoryServiceTest {
                 updated.getDisplayStock().stripTrailingZeros().toPlainString(),
                 updated.getWarehouseStock().stripTrailingZeros().toPlainString()
         );
+        System.out.println("=== BEFORE LOCK SUMMARY ===");
+        System.out.printf(
+                "INITIAL: display=%s, warehouse=%s%n",
+                BigDecimal.valueOf(10).stripTrailingZeros().toPlainString(),
+                BigDecimal.valueOf(20).stripTrailingZeros().toPlainString()
+        );
+        System.out.println("T1 TARGET: display=100, warehouse=20");
+        System.out.println("T2 TARGET: display=10, warehouse=200");
+        System.out.printf(
+                "FINAL: display=%s, warehouse=%s%n",
+                updated.getDisplayStock().stripTrailingZeros().toPlainString(),
+                updated.getWarehouseStock().stripTrailingZeros().toPlainString()
+        );
+        System.out.println("RESULT: lost update reproduced");
+        System.out.println("===========================");
 
         assertThat(results)
                 .extracting(result -> result[0].stripTrailingZeros().toPlainString() + "," + result[1].stripTrailingZeros().toPlainString())
@@ -264,6 +279,112 @@ class InventoryServiceTest {
         ).isTrue();
         assertThat(updated.getDisplayStock().equals(BigDecimal.valueOf(100))
                 && updated.getWarehouseStock().equals(BigDecimal.valueOf(200))).isFalse();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void 비관적_락을_적용한_재고_수정은_동시_요청에도_정합성을_보장한다() throws Exception {
+        // given
+        Store store = newStore("락검증상점");
+        User user = newUser(store, "lockUser");
+        Vendor vendor = newVendor(store, "발주처");
+        Product product = newProduct(store, vendor, "상품1", "LOCK-001");
+
+        InitialInventoryValues initialInventoryValues = new InitialInventoryValues(
+                BigDecimal.ZERO,
+                BigDecimal.valueOf(10),
+                BigDecimal.valueOf(20),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO
+        );
+        inventoryService.createInventory(product, initialInventoryValues);
+        Inventory inventory = inventoryRepository.findByProduct_Id(product.getId())
+                .orElseThrow();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        UpdateInventoryRequest displayUpdateRequest = new UpdateInventoryRequest(
+                product.getId(),
+                BigDecimal.valueOf(100),
+                null,
+                null,
+                null,
+                null
+        );
+        UpdateInventoryRequest warehouseUpdateRequest = new UpdateInventoryRequest(
+                product.getId(),
+                null,
+                BigDecimal.valueOf(200),
+                null,
+                null,
+                null
+        );
+
+        Callable<InventoryResponse> displayTask = () -> {
+            ready.countDown();
+            await(start);
+            InventoryResponse response = inventoryService.updateInventory(inventory.getId(), displayUpdateRequest, user.getId());
+            System.out.printf(
+                    "[LOCK-T1] response display=%s, warehouse=%s%n",
+                    response.displayStock().stripTrailingZeros().toPlainString(),
+                    response.warehouseStock().stripTrailingZeros().toPlainString()
+            );
+            return response;
+        };
+
+        Callable<InventoryResponse> warehouseTask = () -> {
+            ready.countDown();
+            await(start);
+            InventoryResponse response = inventoryService.updateInventory(inventory.getId(), warehouseUpdateRequest, user.getId());
+            System.out.printf(
+                    "[LOCK-T2] response display=%s, warehouse=%s%n",
+                    response.displayStock().stripTrailingZeros().toPlainString(),
+                    response.warehouseStock().stripTrailingZeros().toPlainString()
+            );
+            return response;
+        };
+
+        // when
+        Future<InventoryResponse> displayFuture = executorService.submit(displayTask);
+        Future<InventoryResponse> warehouseFuture = executorService.submit(warehouseTask);
+
+        ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+
+        InventoryResponse firstResponse = displayFuture.get(10, TimeUnit.SECONDS);
+        InventoryResponse secondResponse = warehouseFuture.get(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // then
+        Inventory updated = inventoryRepository.findById(inventory.getId())
+                .orElseThrow();
+        System.out.printf(
+                "[LOCK-FINAL] display=%s, warehouse=%s%n",
+                updated.getDisplayStock().stripTrailingZeros().toPlainString(),
+                updated.getWarehouseStock().stripTrailingZeros().toPlainString()
+        );
+        System.out.println("=== AFTER LOCK SUMMARY ===");
+        System.out.printf(
+                "INITIAL: display=%s, warehouse=%s%n",
+                BigDecimal.valueOf(10).stripTrailingZeros().toPlainString(),
+                BigDecimal.valueOf(20).stripTrailingZeros().toPlainString()
+        );
+        System.out.println("T1 TARGET: display=100, warehouse=20");
+        System.out.println("T2 TARGET: display=10, warehouse=200");
+        System.out.printf(
+                "FINAL: display=%s, warehouse=%s%n",
+                updated.getDisplayStock().stripTrailingZeros().toPlainString(),
+                updated.getWarehouseStock().stripTrailingZeros().toPlainString()
+        );
+        System.out.println("RESULT: both changes preserved");
+        System.out.println("==========================");
+
+        assertThat(firstResponse).isNotNull();
+        assertThat(secondResponse).isNotNull();
+        assertThat(updated.getDisplayStock()).isEqualByComparingTo(BigDecimal.valueOf(100));
+        assertThat(updated.getWarehouseStock()).isEqualByComparingTo(BigDecimal.valueOf(200));
     }
 
     private static void await(CountDownLatch latch) {


### PR DESCRIPTION
## ✨ 작업 내용
- `Inventory` 조회 시 `PESSIMISTIC_WRITE` 기반 비관적 락 적용
- 재고 변경 로직의 락 적용 범위 정리 및 `InventoryService` 중심 처리 구조 통합
- 출고 생성·수정·확정·취소 흐름의 직접 재고 수정 제거 및 공통 재고 변경 경로 적용
- 동시 수정 시 `lost update` 재현 테스트 추가
- 비관적 락 적용 후 정합성 보장 테스트 및 동시 이동 경쟁 제어 테스트 추가

---

## 📝 적용 범위
- `/inventory/repository`
- `/inventory/service`
- `/wholesale/service`

---

## 📌 참고 사항
- 관련 이슈: Closed #192 
- 재고 변경 진입점 전체를 기준으로 락 적용 범위 정리
- `OrderService`, `ReceiptService`는 기존에도 `InventoryService`를 통해 재고를 변경하고 있어 추가 구조 변경 없이 락 적용 효과 반영
- 테스트 리포트에 개선 전/후 및 동시 이동 경쟁 상황 요약 로그 포함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 동시 재고 수정 시 데이터 정합성 개선으로 안정성 강화
  * 재고 예약 관리 기능 추가로 더욱 정확한 재고 추적

* **테스트**
  * 동시 작업 환경에서 재고 일관성 보장 확인하는 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->